### PR TITLE
Infer model from form name.

### DIFF
--- a/lib/active_form/base.rb
+++ b/lib/active_form/base.rb
@@ -5,16 +5,16 @@ module ActiveForm
 
     define_model_callbacks :save, only: [:after]
     after_save :update_form_models
-    
+
     delegate :persisted?, :to_model, :to_key, :to_param, :to_partial_path, to: :model
     attr_reader :model, :forms
-    
+
     def initialize(model)
       @model = model
       @forms = []
       populate_forms
     end
-    
+
     def submit(params)
       params.each do |key, value|
         if nested_params?(value)
@@ -48,12 +48,13 @@ module ActiveForm
 
       collect_errors_from(model)
       aggregate_form_errors
-      
+
       errors.empty?
     end
 
     class << self
-      attr_accessor :main_class, :main_model
+      attr_accessor :main_class
+      attr_writer :main_model
       delegate :reflect_on_association, to: :main_class
 
       def attributes(*names)
@@ -69,7 +70,11 @@ module ActiveForm
       end
 
       def main_class
-        @main_class = main_model.to_s.camelize.constantize
+        @main_class ||= main_model.to_s.camelize.constantize
+      end
+
+      def main_model
+        @main_model ||= name.sub(/Form$/, '').singularize
       end
 
       alias_method :attribute, :attributes

--- a/test/dummy/app/forms/conference_form.rb
+++ b/test/dummy/app/forms/conference_form.rb
@@ -1,5 +1,4 @@
 class ConferenceForm < ActiveForm::Base
-  self.main_model = :conference
   attributes :name, :city, required: true
 
   association :speaker do

--- a/test/dummy/app/forms/project_form.rb
+++ b/test/dummy/app/forms/project_form.rb
@@ -1,5 +1,4 @@
 class ProjectForm < ActiveForm::Base
-  self.main_model = :project
   attributes :name, :description, :owner_id
 
   association :tasks do
@@ -16,7 +15,7 @@ class ProjectForm < ActiveForm::Base
 
   association :project_tags do
     attribute :tag_id
-    
+
     association :tag do
       attribute :name
     end

--- a/test/dummy/app/forms/song_form.rb
+++ b/test/dummy/app/forms/song_form.rb
@@ -1,5 +1,4 @@
 class SongForm < ActiveForm::Base
-  self.main_model = :song
   attributes :title, :length, required: true
 
   association :artist do

--- a/test/dummy/app/forms/survey_form.rb
+++ b/test/dummy/app/forms/survey_form.rb
@@ -1,5 +1,4 @@
 class SurveyForm < ActiveForm::Base
-  self.main_model = :survey
   attribute :name, required: true
 
   association :questions do

--- a/test/fixtures/user_form_fixture.rb
+++ b/test/fixtures/user_form_fixture.rb
@@ -1,5 +1,6 @@
 class UserFormFixture < ActiveForm::Base
   self.main_model = :user
+
   attributes :name, :age, :gender, required: true
 
   validates :name, length: { in: 6..20 }


### PR DESCRIPTION
Hi, Peter! Great work so far. I have a suggestion :smile:

For the simple cases where a model is backed by a form (e.g. a `User` has a `UserForm`) the model can be inferred based on the name of the form.

I've also made the regex strip `Fixture`, which really should be changed to having the form fixtures not having a `Fixture` suffix, but this demonstrates my thinking.

It seems I also have stripped some whitespace for you :smile:
