### PR TITLE
Fixed proc call when form with new record was initialized

### DIFF
--- a/lib/active_form/form_collection.rb
+++ b/lib/active_form/form_collection.rb
@@ -134,11 +134,11 @@ module ActiveForm
 
     def fetch_models
       associated_records = parent.send(association_name)
-      
+
       associated_records.each do |model|
         form = Form.new(association_name, parent, proc, model)
         forms << form
-        form.instance_eval &proc
+        form.instance_eval(&proc) if proc.present?
       end
     end
 
@@ -146,7 +146,7 @@ module ActiveForm
       records.times do
         form = Form.new(association_name, parent, proc)
         forms << form
-        form.instance_eval &proc
+        form.instance_eval(&proc) if proc.present?
       end
     end
 


### PR DESCRIPTION
As I guess from `FormDefinition#initialize`, `proc` is never set.

In my case, it was always `nil` and for new records, the code evaluated `form.instance_eval(&proc)` where `proc` was nil. That lead to `ArgumentError: wrong number of arguments (0 for 1..3)`.
