### PR TITLE
Populating nested errors

### DIFF
--- a/lib/active_form/base.rb
+++ b/lib/active_form/base.rb
@@ -155,7 +155,13 @@ module ActiveForm
 
     def collect_errors_from(validatable_object)
       validatable_object.errors.each do |attribute, error|
-        errors.add(attribute, error)
+        key = if validatable_object.respond_to?(:association_name)
+          "#{validatable_object.association_name}.#{attribute}"
+        else
+          attribute
+        end
+
+        errors.add(key, error)
       end
     end
   end

--- a/lib/active_form/form.rb
+++ b/lib/active_form/form.rb
@@ -77,11 +77,11 @@ module ActiveForm
 
     def submit(params)
       reflection = association_reflection
-      
+
       if reflection.macro == :belongs_to
         @model = parent.send("build_#{association_name}") unless call_reject_if(params_for_current_scope(params))
       end
-      
+
       params.each do |key, value|
         if nested_params?(value)
           fill_association_with_attributes(key, value)
@@ -112,7 +112,7 @@ module ActiveForm
 
       collect_errors_from(model)
       aggregate_form_errors
-      
+
       errors.empty?
     end
 
@@ -132,7 +132,7 @@ module ActiveForm
     def fill_association_with_attributes(association, attributes)
       assoc_name = find_association_name_in(association).to_sym
       form = find_form_by_assoc_name(assoc_name)
-      
+
       form.submit(attributes)
     end
 
@@ -194,7 +194,12 @@ module ActiveForm
 
     def collect_errors_from(validatable_object)
       validatable_object.errors.each do |attribute, error|
-        errors.add(attribute, error)
+        key = if validatable_object.respond_to?(:association_name)
+          "#{validatable_object.association_name}.#{attribute}"
+        else
+          attribute
+        end
+        errors.add(key, error)
       end
     end
   end

--- a/lib/active_form/form_collection.rb
+++ b/lib/active_form/form_collection.rb
@@ -134,7 +134,7 @@ module ActiveForm
 
     def fetch_models
       associated_records = parent.send(association_name)
-      
+
       associated_records.each do |model|
         form = Form.new(association_name, parent, proc, model)
         forms << form

--- a/test/dummy/test/controllers/songs_controller_test.rb
+++ b/test/dummy/test/controllers/songs_controller_test.rb
@@ -39,18 +39,18 @@ class SongsControllerTest < ActionController::TestCase
 
     assert song_form.valid?
     assert_redirected_to song_path(song_form)
-    
+
     assert_equal "Diamonds", song_form.title
     assert_equal "360", song_form.length
-    
+
     assert_equal "Karras", song_form.artist.name
-    
+
     assert_equal "Phoebos", song_form.artist.producer.name
     assert_equal "MADog", song_form.artist.producer.studio
 
     assert song_form.artist.persisted?
     assert song_form.artist.producer.persisted?
-    
+
     assert_equal "Song: Diamonds was successfully created.", flash[:notice]
   end
 
@@ -72,15 +72,20 @@ class SongsControllerTest < ActionController::TestCase
     end
 
     song_form = assigns(:song_form)
-    
+
     assert_not song_form.valid?
-    assert_includes song_form.errors.messages[:title], "can't be blank"
-    assert_includes song_form.errors.messages[:length], "can't be blank"
-    
-    assert_includes song_form.errors.messages[:name], "can't be blank"
-    
-    assert_includes song_form.artist.producer.errors.messages[:name], "can't be blank"
-    assert_includes song_form.errors.messages[:studio], "can't be blank"
+
+    assert_includes song_form.errors[:title], "can't be blank"
+    assert_includes song_form.errors[:length], "can't be blank"
+
+    assert_includes song_form.errors["artist.name"], "can't be blank"
+    assert_includes song_form.artist.errors[:name], "can't be blank"
+
+    assert_includes song_form.artist.producer.errors[:name], "can't be blank"
+    assert_includes song_form.artist.producer.errors[:studio], "can't be blank"
+
+    assert_includes song_form.errors["artist.producer.name"], "can't be blank"
+    assert_includes song_form.errors["artist.producer.studio"], "can't be blank"
   end
 
   test "should show song" do
@@ -109,19 +114,19 @@ class SongsControllerTest < ActionController::TestCase
         }
       }
     end
-    
+
     song_form = assigns(:song_form)
 
     assert_redirected_to song_path(song_form)
-    
+
     assert_equal "Run this town", song_form.title
     assert_equal "355", song_form.length
-    
+
     assert_equal "Rihanna", song_form.artist.name
-    
+
     assert_equal "Eminem", song_form.artist.producer.name
     assert_equal "Marshall", song_form.artist.producer.studio
-    
+
     assert_equal "Song: Run this town was successfully updated.", flash[:notice]
   end
 

--- a/test/forms/conference_form_test.rb
+++ b/test/forms/conference_form_test.rb
@@ -98,22 +98,30 @@ class ConferenceFormTest < ActiveSupport::TestCase
     @form.submit({})
 
     assert_not @form.valid?
-    assert_includes @form.errors.messages[:name], "can't be blank"
-    assert_includes @form.errors.messages[:city], "can't be blank"
-    assert_equal 2, @form.errors.messages[:name].size
-    assert_includes @form.errors.messages[:occupation], "can't be blank"
-    assert_includes @form.errors.messages[:topic], "can't be blank"
-    assert_equal 2, @form.errors.messages[:topic].size
-    assert_includes @form.errors.messages[:duration], "can't be blank"
-    assert_equal 2, @form.errors.messages[:duration].size
+
+    assert_includes @form.errors[:name], "can't be blank"
+    assert_equal 1, @form.errors[:name].size
+    assert_includes @form.errors[:city], "can't be blank"
+    assert_equal 1, @form.errors[:city].size
+
+    assert_includes @form.errors["speaker.name"], "can't be blank"
+
+    assert_includes @form.errors["speaker.occupation"], "can't be blank"
+
+    assert_includes @form.errors["speaker.presentations.topic"], "can't be blank"
+    assert_equal 2, @form.errors["speaker.presentations.topic"].size
+
+    assert_includes @form.errors["speaker.presentations.duration"], "can't be blank"
+    assert_equal 2, @form.errors["speaker.presentations.duration"].size
   end
 
   test "main form validates the models" do
     @form.submit(speaker_attributes: { name: conferences(:ruby).speaker.name })
 
     assert_not @form.valid?
-    assert_includes @form.errors.messages[:name], "has already been taken"
-    assert_equal 2, @form.errors.messages[:name].size
+
+    assert_includes @form.errors["name"], "can't be blank"
+    assert_includes @form.errors["speaker.name"], "has already been taken"
   end
 
   test "presentations sub-form raises error if records exceed the allowed number" do

--- a/test/forms/nested_model_form_test.rb
+++ b/test/forms/nested_model_form_test.rb
@@ -89,7 +89,7 @@ class NestedModelFormTest < ActiveSupport::TestCase
   test "email sub-form validates the model" do
     existing_email = emails(:peters)
     @email_form.address = existing_email.address
-    
+
     assert_not @email_form.valid?
     assert_includes @email_form.errors.messages[:address], "has already been taken"
 
@@ -138,7 +138,7 @@ class NestedModelFormTest < ActiveSupport::TestCase
     assert_equal 23, @form.age
     assert_equal 0, @form.gender
     assert_equal "petrakos@gmail.com", @email_form.address
-    
+
     assert @form.persisted?
     assert @email_form.persisted?
   end
@@ -174,7 +174,7 @@ class NestedModelFormTest < ActiveSupport::TestCase
       name: peter.name,
       age: "23",
       gender: "0",
-      
+
       email_attributes: {
         address: peter.email.address
       }
@@ -186,8 +186,8 @@ class NestedModelFormTest < ActiveSupport::TestCase
       @form.save
     end
 
-    assert_includes @form.errors.messages[:name], "has already been taken"
-    assert_includes @form.errors.messages[:address], "has already been taken"
+    assert_includes @form.errors[:name], "has already been taken"
+    assert_includes @form.errors["email.address"], "has already been taken"
   end
 
   test "main form collects all the form specific errors" do
@@ -205,9 +205,10 @@ class NestedModelFormTest < ActiveSupport::TestCase
 
     assert_not @form.valid?
 
-    [:name, :age, :gender, :address].each do |attribute|
-      assert_includes @form.errors.messages[attribute], "can't be blank"
-    end
+    assert_includes @form.errors[:name], "can't be blank"
+    assert_includes @form.errors[:age], "can't be blank"
+    assert_includes @form.errors[:gender], "can't be blank"
+    assert_includes @form.errors["email.address"], "can't be blank"
   end
 
   test "main form responds to writer method" do

--- a/test/forms/nested_models_form_test.rb
+++ b/test/forms/nested_models_form_test.rb
@@ -29,7 +29,7 @@ class NestedModelsFormTest < ActiveSupport::TestCase
 
   test "profile sub-form declares attributes" do
     attributes = [:twitter_name, :twitter_name=, :github_name, :github_name=]
-    
+
     attributes.each do |attribute|
       assert_respond_to @profile_form, attribute
     end
@@ -41,7 +41,7 @@ class NestedModelsFormTest < ActiveSupport::TestCase
 
     assert_equal "twitter_peter", @profile_form.twitter_name
     assert_equal "twitter_peter", @profile_form.model.twitter_name
-    
+
     assert_equal "github_peter", @profile_form.github_name
     assert_equal "github_peter", @profile_form.model.github_name
   end
@@ -137,7 +137,7 @@ class NestedModelsFormTest < ActiveSupport::TestCase
     assert_equal "petrakos@gmail.com", @form.email.address
     assert_equal "t_peter", @profile_form.twitter_name
     assert_equal "g_peter", @profile_form.github_name
-    
+
     assert @form.persisted?
     assert @form.email.persisted?
     assert @profile_form.persisted?
@@ -181,7 +181,7 @@ class NestedModelsFormTest < ActiveSupport::TestCase
       name: peter.name,
       age: "23",
       gender: "0",
-      
+
       email_attributes: {
         address: peter.email.address
       },
@@ -198,10 +198,10 @@ class NestedModelsFormTest < ActiveSupport::TestCase
       @form.save
     end
 
-    assert_includes @form.errors.messages[:name], "has already been taken"
-    assert_includes @form.errors.messages[:address], "has already been taken"
-    assert_includes @form.errors.messages[:twitter_name], "has already been taken"
-    assert_includes @form.errors.messages[:github_name], "has already been taken"
+    assert_includes @form.errors[:name], "has already been taken"
+    assert_includes @form.errors["email.address"], "has already been taken"
+    assert_includes @form.errors["profile.twitter_name"], "has already been taken"
+    assert_includes @form.errors["profile.github_name"], "has already been taken"
   end
 
   test "main form collects all the form specific errors" do
@@ -224,9 +224,12 @@ class NestedModelsFormTest < ActiveSupport::TestCase
 
     assert_not @form.valid?
 
-    [:name, :age, :gender, :address, :twitter_name, :github_name].each do |attribute|
-      assert_includes @form.errors.messages[attribute], "can't be blank"
-    end
+    assert_includes @form.errors[:name], "can't be blank"
+    assert_includes @form.errors[:age], "can't be blank"
+    assert_includes @form.errors[:gender], "can't be blank"
+    assert_includes @form.errors["email.address"], "can't be blank"
+    assert_includes @form.errors["profile.twitter_name"], "can't be blank"
+    assert_includes @form.errors["profile.github_name"], "can't be blank"
   end
 
   test "main form responds to writer method" do

--- a/test/forms/two_nested_collections_form_test.rb
+++ b/test/forms/two_nested_collections_form_test.rb
@@ -46,7 +46,7 @@ class TwoNestedCollectionsFormTest < ActiveSupport::TestCase
     questions_form = @form.forms.first
 
     assert_equal 1, questions_form.forms.size
-    
+
     @form.questions.each do |question_form|
       assert_instance_of ActiveForm::Form, question_form
       assert_instance_of Question, question_form.model
@@ -66,7 +66,7 @@ class TwoNestedCollectionsFormTest < ActiveSupport::TestCase
 
     assert_respond_to questions_form, :models
     assert_equal 1, questions_form.models.size
-    
+
     questions_form.each do |form|
       assert_instance_of ActiveForm::Form, form
       assert_instance_of Question, form.model
@@ -164,8 +164,10 @@ class TwoNestedCollectionsFormTest < ActiveSupport::TestCase
     @form.submit(params)
 
     assert_not @form.valid?
-    assert_includes @form.errors.messages[:name], "can't be blank"
-    assert_includes @form.errors.messages[:content], "can't be blank"
+
+    assert_includes @form.errors[:name], "can't be blank"
+    assert_includes @form.errors["questions.content"], "can't be blank"
+    assert_includes @form.errors["questions.answers.content"], "can't be blank"
   end
 
   test "main form validates the model" do

--- a/test/forms/two_nesting_level_form_test.rb
+++ b/test/forms/two_nesting_level_form_test.rb
@@ -106,10 +106,10 @@ class TwoNestingLevelFormTest < ActiveSupport::TestCase
     @form.submit(params)
 
     assert_not @form.valid?
-    assert_includes @form.errors.messages[:title], "can't be blank"
-    assert_includes @form.errors.messages[:length], "can't be blank"
-    assert_includes @form.errors.messages[:name], "can't be blank"
-    assert_includes @form.errors.messages[:studio], "can't be blank"
+    assert_includes @form.errors[:title], "can't be blank"
+    assert_includes @form.errors[:length], "can't be blank"
+    assert_includes @form.errors["artist.name"], "can't be blank"
+    assert_includes @form.errors["artist.producer.studio"], "can't be blank"
 
     @form.title = "Diamonds"
     @form.length = "355"
@@ -135,14 +135,14 @@ class TwoNestingLevelFormTest < ActiveSupport::TestCase
         }
       }
     }
-    
+
     @form.submit(params)
 
     assert_not @form.valid?
-    assert_includes @form.errors.messages[:title], "has already been taken"
-    assert_includes @form.errors.messages[:name], "has already been taken"
-    assert_equal 2, @form.errors.messages[:name].size
-    assert_includes @form.errors.messages[:studio], "has already been taken"
+    assert_includes @form.errors[:title], "has already been taken"
+    assert_includes @form.errors["artist.name"], "has already been taken"
+    assert_includes @form.errors["artist.producer.name"], "has already been taken"
+    assert_includes @form.errors["artist.producer.studio"], "has already been taken"
   end
 
   test "main form saves its model and the models in nested sub-forms" do


### PR DESCRIPTION
As I reported in #10, error keys get duplicated and we should namespace them.
This code behaves right like AR::Base accept_nested_attributes
