### PR TITLE
Default insertion node just above add link

### DIFF
--- a/app/assets/javascripts/action_form.js
+++ b/app/assets/javascripts/action_form.js
@@ -24,7 +24,7 @@
         insertionNode = insertionNode == "this" ? $link : $(insertionNode);
       }
     } else {
-      insertionNode = $link.parent();
+      insertionNode = $link;
     }
 
     var contentNode = $(newContent);


### PR DESCRIPTION
Take the example conference form:

```
New Conference
  Name: _______
  City: _______
  Speaker:
    Name: _______
    Topic: _______
    Duration: _______
  Speaker:
    Name: _______
    Topic: _______
    Duration: _______
  [New Speaker]
[Create Conference]
```

By default, when you click New Speaker, speaker fields are added above and outside the form itself. That's because by default, new fields get inserted above the parent of the link, which happens to be the form if you go by the examples in cocoon and actionform. Even if you wrap the speakers in a container element, new fields would be added before and outside the rest of the speakers. When they re-display after saving, they would be below the previously added speakers.

This PR aims to change the behavior to make new fields appear just above the `link_to_add_association`. I believe this is the most sensible default. It's still 100% customizable if need be.
